### PR TITLE
[FEAT] : 제품 리스트 페이지 및 제품 상세 페이지 헤더, 푸터 조립 

### DIFF
--- a/src/pages/product_detail_page.html
+++ b/src/pages/product_detail_page.html
@@ -12,6 +12,212 @@
     <script type="module" src="/src/main.js"></script>
   </head>
   <body>
+    <div style="width: 100%; ">
+      <div style="background-color:var(--gray-50);">
+      <header class="header1" style="max-width: 1920px; margin-inline:auto;">
+        <nav>
+          <span>매장찾기 ㅣ</span>
+          <span>고객센터 ㅣ</span>
+          <span>가입하기 ㅣ</span>
+          <span>로그인</span>
+        </nav>
+      </header>
+    </div>
+      <header class="header2" style="position: static; max-width: 1920px; margin-inline:auto;">
+        <a href="/" class="logo" style="margin-left:24px;">
+          <svg width="59" height="21" viewBox="0 0 59 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M58.854 0L15.8132 18.2574C12.2297 19.7777 9.21516 20.5363 6.78586 20.5363C4.05249 20.5363 2.06131 19.5717 0.83849 17.6459C-0.747258 15.1611 -0.0541062 11.1656 2.66619 6.94786C4.28136 4.4826 6.33466 2.22005 8.33564 0.0555836C7.86482 0.820666 3.70918 7.73584 8.25391 10.9923C9.15304 11.6463 10.4314 11.9667 12.0041 11.9667C13.2662 11.9667 14.7146 11.7607 16.3069 11.3455L58.854 0Z" fill="#111111" />
+          </svg>
+        </a>
+        <nav class="nav-app">
+          <div class="search">
+            <a href="/" aria-label="검색"
+              ><svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M10.962 13.296C9.91599 13.9224 8.71921 14.2521 7.50001 14.25C6.6134 14.2512 5.7353 14.0772 4.91618 13.7379C4.09707 13.3986 3.35308 12.9008 2.72701 12.273C2.09924 11.6469 1.6014 10.9029 1.26212 10.0838C0.922837 9.26471 0.748797 8.38661 0.750006 7.50001C0.750006 5.63601 1.50501 3.94901 2.72701 2.72701C3.35308 2.09924 4.09707 1.6014 4.91618 1.26212C5.7353 0.922837 6.6134 0.748797 7.50001 0.750006C9.36401 0.750006 11.051 1.50501 12.273 2.72701C12.9008 3.35308 13.3986 4.09707 13.7379 4.91618C14.0772 5.7353 14.2512 6.6134 14.25 7.50001C14.2517 8.69741 13.9338 9.87357 13.329 10.907C12.812 11.789 12.895 12.895 13.618 13.618L17.471 17.471"
+                  stroke="#111111"
+                  stroke-width="1.5"
+                />
+              </svg>
+            </a>
+          </div>
+          <div class="my-info">
+            <a href="/" aria-label="내 정보"
+              ><svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M0.75 18V15C0.75 14.0054 1.14509 13.0516 1.84835 12.3483C2.55161 11.6451 3.50544 11.25 4.5 11.25H13.5C14.4946 11.25 15.4484 11.6451 16.1517 12.3483C16.8549 13.0516 17.25 14.0054 17.25 15V18M9 0.75C8.00544 0.75 7.05161 1.14509 6.34835 1.84835C5.64509 2.55161 5.25 3.50544 5.25 4.5C5.25 5.49456 5.64509 6.44839 6.34835 7.15165C7.05161 7.85491 8.00544 8.25 9 8.25C9.99456 8.25 10.9484 7.85491 11.6517 7.15165C12.3549 6.44839 12.75 5.49456 12.75 4.5C12.75 3.50544 12.3549 2.55161 11.6517 1.84835C10.9484 1.14509 9.99456 0.75 9 0.75Z"
+                  stroke="#111111"
+                  stroke-width="1.5"
+                />
+              </svg>
+            </a>
+          </div>
+          <div class="shopping-cart">
+            <a href="/" aria-label="장바구니"
+              ><svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M5.25 5.25V3C5.25 2.40326 5.48705 1.83097 5.90901 1.40901C6.33097 0.987053 6.90326 0.75 7.5 0.75H10.5C11.0967 0.75 11.669 0.987053 12.091 1.40901C12.5129 1.83097 12.75 2.40326 12.75 3C12.75 3.59674 12.5129 4.16903 12.091 4.59099C11.669 5.01295 11.0967 5.25 10.5 5.25H0.75V13.5C0.75 14.4946 1.14509 15.4484 1.84835 16.1517C2.55161 16.8549 3.50544 17.25 4.5 17.25H13.5C14.4946 17.25 15.4484 16.8549 16.1517 16.1517C16.8549 15.4484 17.25 14.4946 17.25 13.5V5.25H14.5"
+                  stroke="#111111"
+                  stroke-width="1.5"
+                />
+              </svg>
+            </a>
+          </div>
+          <input type="checkbox" id="menu-btn" />
+          <label tabindex="0" for="menu-btn" class="menu"
+            ><svg width="18" height="16" viewBox="0 0 18 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M18 1.25H0M18 8H0M18 14.75H0" stroke="#111111" stroke-width="1.5" />
+            </svg>
+          </label>
+
+          <div class="menu-list" style="min-width:320px;">
+            <label tabindex="0" for="menu-btn" class="menu-close-btn">
+              <svg width="29" height="29" viewBox="0 0 29 29" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <g opacity="0.18">
+                  <circle cx="14.5" cy="14.5" r="14.5" fill="#E5E5E5" />
+                  <path d="M6 7L21.9995 23" stroke="#111111" stroke-width="2" />
+                  <path d="M22 7L6.0005 23" stroke="#111111" stroke-width="2" />
+                </g>
+              </svg>
+            </label>
+
+            <div class="menu-user-btn">
+              <a href="/" class="togo-filled-00">가입하기</a>
+              <a href="/" class="togo-outlined-00">로그인</a>
+            </div>
+
+            <ul class="menu-category">
+              <li>
+                <a href="/"
+                  ><span>New & Featured</span
+                  ><svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M14.4854 10L22.9706 18.4853L14.4854 26.9706" stroke="#111111" stroke-width="2" />
+                  </svg>
+                </a>
+              </li>
+              <li>
+                <a href="/"
+                  ><span>Men</span
+                  ><svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M14.4854 10L22.9706 18.4853L14.4854 26.9706" stroke="#111111" stroke-width="2" />
+                  </svg>
+                </a>
+              </li>
+              <li>
+                <a href="/"
+                  ><span>Women</span
+                  ><svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M14.4854 10L22.9706 18.4853L14.4854 26.9706" stroke="#111111" stroke-width="2" />
+                  </svg>
+                </a>
+              </li>
+              <li>
+                <a href="/"
+                  ><span>Kids</span
+                  ><svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M14.4854 10L22.9706 18.4853L14.4854 26.9706" stroke="#111111" stroke-width="2" />
+                  </svg>
+                </a>
+              </li>
+              <li>
+                <a href="/"
+                  ><span>Sale</span
+                  ><svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M14.4854 10L22.9706 18.4853L14.4854 26.9706" stroke="#111111" stroke-width="2" />
+                  </svg>
+                </a>
+              </li>
+            </ul>
+            <ul class="menu-etc">
+              <a href="/"
+                ><li>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M11.99 18V16.5M9 9.75C9.00027 9.21339 9.14447 8.68668 9.41756 8.22476C9.69065 7.76284 10.0826 7.38262 10.5527 7.12373C11.0227 6.86485 11.5536 6.73678 12.0899 6.75286C12.6263 6.76895 13.1485 6.9286 13.6022 7.21519C14.0559 7.50177 14.4244 7.9048 14.6693 8.38225C14.9142 8.85971 15.0266 9.39411 14.9947 9.92978C14.9628 10.4654 14.7878 10.9827 14.488 11.4278C14.1882 11.8728 13.7745 12.2293 13.29 12.46C12.51 12.83 12 13.62 12 14.49V15M21.75 12C21.75 17.385 17.385 21.75 12 21.75C6.615 21.75 2.25 17.385 2.25 12C2.25 6.615 6.615 2.25 12 2.25C17.385 2.25 21.75 6.615 21.75 12Z"
+                      stroke="#111111"
+                      stroke-width="1.5"
+                      stroke-miterlimit="10"
+                    />
+                  </svg>
+                  <span>고객센터</span>
+                </li>
+              </a>
+              <a href="/"
+                ><li>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M8.25 8.25V6C8.25 5.40326 8.48705 4.83097 8.90901 4.40901C9.33097 3.98705 9.90326 3.75 10.5 3.75H13.5C14.0967 3.75 14.669 3.98705 15.091 4.40901C15.5129 4.83097 15.75 5.40326 15.75 6C15.75 6.59674 15.5129 7.16903 15.091 7.59099C14.669 8.01295 14.0967 8.25 13.5 8.25H3.75V16.5C3.75 17.4946 4.14509 18.4484 4.84835 19.1517C5.55161 19.8549 6.50544 20.25 7.5 20.25H16.5C17.4946 20.25 18.4484 19.8549 19.1517 19.1517C19.8549 18.4484 20.25 17.4946 20.25 16.5V8.25H17.5"
+                      stroke="#111111"
+                      stroke-width="1.5"
+                    />
+                  </svg>
+
+                  <span>장바구니</span>
+                </li>
+              </a>
+              <a href="/"
+                ><li>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M12 13.5V6.5C12 4.76 13.01 3.75 14.25 3.75H18.64L20.25 9.75M20.25 9.75H3.75M20.25 9.75V20.25H3.75V9.75M3.75 9.75L5.36 3.75H10.5" stroke="#111111" stroke-width="1.5" stroke-miterlimit="10" />
+                  </svg>
+
+                  <span>주문</span>
+                </li>
+              </a>
+              <a href="/"
+                ><li>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M20.25 5.25V16.5C20.25 17.74 19.24 18.75 18 18.75H6C4.76 18.75 3.75 17.74 3.75 16.5V5.25M8.25 18.5V11.25H15.75V18.5M12 11.25V18.5M1.5 5.25H22.5" stroke="#111111" stroke-width="1.5" stroke-miterlimit="10" />
+                  </svg>
+
+                  <span>매장 찾기</span>
+                </li>
+              </a>
+            </ul>
+          </div>
+          <div class="overlay"></div>
+        </nav>
+
+        <nav class="nav-web1" style="padding-left: 150px;">
+          <div><a href="/">New & Featured</a></div>
+          <div><a href="/">Men</a></div>
+          <div><a href="/">Women</a></div>
+          <div><a href="/">Kids</a></div>
+          <div><a href="/">Sale</a></div>
+        </nav>
+        <nav class="nav-web2">
+          <form action="/" class="header__search-input" method="GET">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M13.962 16.296C12.916 16.9224 11.7192 17.2521 10.5 17.25C9.6134 17.2512 8.7353 17.0772 7.91618 16.7379C7.09707 16.3986 6.35308 15.9008 5.72701 15.273C5.09924 14.6469 4.6014 13.9029 4.26212 13.0838C3.92284 12.2647 3.7488 11.3866 3.75001 10.5C3.75001 8.63601 4.50501 6.94901 5.72701 5.72701C6.35308 5.09924 7.09707 4.6014 7.91618 4.26212C8.7353 3.92284 9.6134 3.7488 10.5 3.75001C12.364 3.75001 14.051 4.50501 15.273 5.72701C15.9008 6.35308 16.3986 7.09707 16.7379 7.91618C17.0772 8.7353 17.2512 9.6134 17.25 10.5C17.2517 11.6974 16.9338 12.8736 16.329 13.907C15.812 14.789 15.895 15.895 16.618 16.618L20.471 20.471"
+                stroke="#111111"
+                stroke-width="1.5"
+              />
+            </svg>
+            <label for="header__search-input" class="sr-only">매장 위치 검색</label>
+            <input class="header__search-input__input" type="text" id="header__search-input" placeholder="검색" name="header__search-input__name" />
+          </form>
+          <a href="/" aria-label="위시리스트">
+            <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M22.794 9.75002C24.118 9.75002 25.362 10.266 26.298 11.201C27.2262 12.1309 27.7475 13.3911 27.7475 14.705C27.7475 16.0189 27.2262 17.2791 26.298 18.209L18 26.508L9.70096 18.209C8.77307 17.2791 8.25195 16.0192 8.25195 14.7055C8.25195 13.3919 8.77307 12.1319 9.70096 11.202C10.16 10.7403 10.706 10.3743 11.3075 10.125C11.909 9.87578 12.5539 9.74832 13.205 9.75002C14.529 9.75002 15.773 10.266 16.709 11.201L17.469 11.961L18 12.492L18.53 11.961L19.29 11.201C19.7492 10.7396 20.2953 10.3738 20.8967 10.1248C21.4982 9.87573 22.143 9.74835 22.794 9.75002Z"
+                stroke="#111111"
+                stroke-width="1.5"
+              />
+            </svg>
+          </a>
+          <a href="/" aria-label="장바구니"
+            ><svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M14.25 14.25V12C14.25 11.4033 14.4871 10.831 14.909 10.409C15.331 9.98705 15.9033 9.75 16.5 9.75H19.5C20.0967 9.75 20.669 9.98705 21.091 10.409C21.5129 10.831 21.75 11.4033 21.75 12C21.75 12.5967 21.5129 13.169 21.091 13.591C20.669 14.0129 20.0967 14.25 19.5 14.25H9.75V22.5C9.75 23.4946 10.1451 24.4484 10.8483 25.1517C11.5516 25.8549 12.5054 26.25 13.5 26.25H22.5C23.4946 26.25 24.4484 25.8549 25.1517 25.1517C25.8549 24.4484 26.25 23.4946 26.25 22.5V14.25H23.5"
+                stroke="#111111"
+                stroke-width="1.5"
+              />
+            </svg>
+          </a>
+        </nav>
+      </header>
+    </div>
     <div class="product-detail-page">
       <div class="product-detail-page__content-grid">
         <div class="product-detail-page__gallery-panel">
@@ -90,7 +296,7 @@
             </ul>
           </div>
           <div class="product-options__details-link-container"><button class="product-options__details-link">상품 상세 정보 보기</button></div>
-          
+
           <div class="product-info-accordion">
             <details class="product-info-accordion__item">
               <summary class="product-info-accordion__item-summary">
@@ -109,102 +315,102 @@
               </div>
             </details>
             <details class="product-info-accordion__item">
-                <summary class="product-info-accordion__item-summary">
-                  <div class="product-info-accordion__header">
-                    <span class="product-info-accordion__title">무료 배송 및 반품</span>
-                    <span class="product-info-accordion__icon">아이콘</span>
-                  </div>
-                </summary>
-                <div class="product-info-accordion__content-wrapper">
-                  <div class="product-info-accordion__content">
-                    <p><strong>일반 배송&nbsp;</strong></p>
-                    <p>• 배송지역: 전국 (일부 지역 제외)</p>
-                    <p>• 배송비: 무료배송</p>
-                    <p>• 제품 수령일로부터 14일 이내 제품에 대해서만 무료 반품 서비스가 가능합니다.</p>
-                    <p>• 나이키는 교환 서비스를 제공하지 않습니다.</p>
-                    <p>일반 배송 <a href="https://www.nike.com/kr/help/a/shipping-delivery-kr">자세히 알아보기</a></p>
-                    <p>반품 <a href="https://www.nike.com/kr/help/a/how-to-return-kr">자세히 알아보기</a></p>
-                    <p><br /></p>
-                    <p><strong>오늘도착 서비스</strong></p>
-                    <p>• 이용시간: 오전 10시 30분까지 결제 시, 당일 도착 (일요일, 공휴일 제외)</p>
-                    <p>• 서비스지역: 서울∙과천∙의왕∙군포∙수원∙성남∙안양시 전체, 용인시 수지구∙기흥구, 부천시 중동∙상동∙심곡동</p>
-                    <p>• 서비스비용: 5,000원</p>
-                    <p><a href="https://www.nike.com/kr/help/a/shipping-delivery-kr">자세히 알아보기</a></p>
-                    <p>&nbsp;</p>
-                    <p><strong>A/S 안내&nbsp;</strong></p>
-                    <p>• 나이키 온라인에서 구매하신 제품에 대한 A/S 는 나이키코리아 고객센터(<a href="tel:080-022-0182">080-022-0182</a>)에서 유선으로만 접수 가능합니다.</p>
-                    <p><a href="https://www.nike.com/kr/help/a/a-s-apply-kr">자세히 알아보기</a></p>
-                  </div>
+              <summary class="product-info-accordion__item-summary">
+                <div class="product-info-accordion__header">
+                  <span class="product-info-accordion__title">무료 배송 및 반품</span>
+                  <span class="product-info-accordion__icon">아이콘</span>
                 </div>
-              </details>
-              <details class="product-info-accordion__item">
-                <summary class="product-info-accordion__item-summary">
-                  <div class="product-info-accordion__header">
-                    <span class="product-info-accordion__title">제작 과정</span>
-                    <span class="product-info-accordion__icon">아이콘</span>
-                  </div>
-                </summary>
-                <div class="product-info-accordion__content-wrapper">
-                  <div class="product-info-accordion__content">
-                    <ul>
-                      <li>사용 및 제조 후 발생한 폐기물의 재생 소재를 활용하여 책임감 있게 디자인한 제품입니다. 탄소 제로, 폐기물 제로를 달성하기 위해 나이키는 신중하게 소재를 선택합니다. 제품 개발 과정에서 발생하는 탄소 발자국의 70%가 소재에서 발생하기 때문입니다. 나이키는 플라스틱과 원사, 직물을 재활용하여 탄소 배출량을 크게 줄이고 있습니다. 나이키의 목표는 성능과 내구성, 스타일을 그대로 유지하면서도 가능한 한 많은 재생 소재를 사용하는 것입니다.</li>
-                      <li>우리가 스포츠를 즐기며 살아가는 지구의 미래를 보호하기 위한 나이키의 노력과 지속 가능성을 염두에 둔 제품 디자인 등 탄소 제로 및 폐기물 제로를 향한 나이키의 <a href="#" target="_blank" rel="noreferrer">Move to Zero</a> 여정에 대해 자세히 알아보세요.</li>
-                    </ul>
-                  </div>
+              </summary>
+              <div class="product-info-accordion__content-wrapper">
+                <div class="product-info-accordion__content">
+                  <p><strong>일반 배송&nbsp;</strong></p>
+                  <p>• 배송지역: 전국 (일부 지역 제외)</p>
+                  <p>• 배송비: 무료배송</p>
+                  <p>• 제품 수령일로부터 14일 이내 제품에 대해서만 무료 반품 서비스가 가능합니다.</p>
+                  <p>• 나이키는 교환 서비스를 제공하지 않습니다.</p>
+                  <p>일반 배송 <a href="https://www.nike.com/kr/help/a/shipping-delivery-kr">자세히 알아보기</a></p>
+                  <p>반품 <a href="https://www.nike.com/kr/help/a/how-to-return-kr">자세히 알아보기</a></p>
+                  <p><br /></p>
+                  <p><strong>오늘도착 서비스</strong></p>
+                  <p>• 이용시간: 오전 10시 30분까지 결제 시, 당일 도착 (일요일, 공휴일 제외)</p>
+                  <p>• 서비스지역: 서울∙과천∙의왕∙군포∙수원∙성남∙안양시 전체, 용인시 수지구∙기흥구, 부천시 중동∙상동∙심곡동</p>
+                  <p>• 서비스비용: 5,000원</p>
+                  <p><a href="https://www.nike.com/kr/help/a/shipping-delivery-kr">자세히 알아보기</a></p>
+                  <p>&nbsp;</p>
+                  <p><strong>A/S 안내&nbsp;</strong></p>
+                  <p>• 나이키 온라인에서 구매하신 제품에 대한 A/S 는 나이키코리아 고객센터(<a href="tel:080-022-0182">080-022-0182</a>)에서 유선으로만 접수 가능합니다.</p>
+                  <p><a href="https://www.nike.com/kr/help/a/a-s-apply-kr">자세히 알아보기</a></p>
                 </div>
-              </details>
-              <details class="product-info-accordion__item">
-                <summary class="product-info-accordion__item-summary">
-                  <div class="product-info-accordion__header">
-                    <span class="product-info-accordion__title">리뷰(36)</span>
-                    <span class="product-info-accordion__icon">아이콘</span>
-                  </div>
-                </summary>
-                <div class="product-info-accordion__content-wrapper">
-                  <div class="product-info-accordion__content">
-                    <ul>
-                      <li>정사이즈보다 작게 나온 제품으로, 반 사이즈 크게 주문하는 것을 추천드립니다.</li>
-                      <li><a href="#" target="_blank" rel="noreferrer">사이즈 가이드</a></li>
-                    </ul>
-                  </div>
+              </div>
+            </details>
+            <details class="product-info-accordion__item">
+              <summary class="product-info-accordion__item-summary">
+                <div class="product-info-accordion__header">
+                  <span class="product-info-accordion__title">제작 과정</span>
+                  <span class="product-info-accordion__icon">아이콘</span>
                 </div>
-              </details>
-              <details class="product-info-accordion__item">
-                <summary class="product-info-accordion__item-summary">
-                  <div class="product-info-accordion__header">
-                    <span class="product-info-accordion__title">추가 정보</span>
-                    <span class="product-info-accordion__icon">아이콘</span>
-                  </div>
-                </summary>
-                <div class="product-info-accordion__content-wrapper">
-                  <div class="product-info-accordion__content">
-                    <p>상품정보제공고시</p>
-                    <ul>
-                      <li>제조연월: 수입제품으로 각 제품별 입고 시기에 따라 상이하여 정확한 제조연월 제공이 어렵습니다. 제조연월을 확인하시려면 고객센터에 문의하시기 바라며, 정확한 제조연월은 배송받으신 제품의 라벨을 참고하시기 바랍니다.</li>
-                    </ul>
-                    <ul>
-                      <li>A/S 책임자와 전화번호: (유)나이키코리아 온라인 스토어 고객센터 / 080-022-0182</li>
-                      <li>세탁방법 및 취급시 주의사항: 자세한 내용은 '<a href="#">자세히 보기</a>'를 클릭하여 확인 부탁드립니다.</li>
-                      <li>미성년자 권리 보호 안내: 자세한 내용은 '<a href="#">자세히 보기</a>' 를 클릭하여 확인 부탁드립니다.</li>
-                      <li>품질보증기준: 품질보증기간-섬유 및 일반 소재(구입 후 6개월), 가죽소재(구입 후 1년). 유통 중 손상되었거나 품질에 이상이 있는 제품에 한하여 소비자 피해 보상 규정에 의거 보상하여 드립니다. 단, 제품에 부착되어 있는 사용방법 및 취급 시 주의사항에 따라 제품을 관리해 주시고, 소비자 부주의로 인한 품질 이상 및 변형에 대해서는 책임을 지지 않습니다.</li>
-                    </ul>
-                    <ul>
-                      <li>실제 제품에는 재활용 소재 관련 내용이 표기되지 않을 수 있습니다.</li>
-                    </ul>
-                    <ul>
-                      <li>제조자/수입품의 경우 수입자를 함께 표기: Nike. Inc / (유)나이키코리아</li>
-                    </ul>
-                  </div>
+              </summary>
+              <div class="product-info-accordion__content-wrapper">
+                <div class="product-info-accordion__content">
+                  <ul>
+                    <li>사용 및 제조 후 발생한 폐기물의 재생 소재를 활용하여 책임감 있게 디자인한 제품입니다. 탄소 제로, 폐기물 제로를 달성하기 위해 나이키는 신중하게 소재를 선택합니다. 제품 개발 과정에서 발생하는 탄소 발자국의 70%가 소재에서 발생하기 때문입니다. 나이키는 플라스틱과 원사, 직물을 재활용하여 탄소 배출량을 크게 줄이고 있습니다. 나이키의 목표는 성능과 내구성, 스타일을 그대로 유지하면서도 가능한 한 많은 재생 소재를 사용하는 것입니다.</li>
+                    <li>우리가 스포츠를 즐기며 살아가는 지구의 미래를 보호하기 위한 나이키의 노력과 지속 가능성을 염두에 둔 제품 디자인 등 탄소 제로 및 폐기물 제로를 향한 나이키의 <a href="#" target="_blank" rel="noreferrer">Move to Zero</a> 여정에 대해 자세히 알아보세요.</li>
+                  </ul>
                 </div>
-              </details>
+              </div>
+            </details>
+            <details class="product-info-accordion__item">
+              <summary class="product-info-accordion__item-summary">
+                <div class="product-info-accordion__header">
+                  <span class="product-info-accordion__title">리뷰(36)</span>
+                  <span class="product-info-accordion__icon">아이콘</span>
+                </div>
+              </summary>
+              <div class="product-info-accordion__content-wrapper">
+                <div class="product-info-accordion__content">
+                  <ul>
+                    <li>정사이즈보다 작게 나온 제품으로, 반 사이즈 크게 주문하는 것을 추천드립니다.</li>
+                    <li><a href="#" target="_blank" rel="noreferrer">사이즈 가이드</a></li>
+                  </ul>
+                </div>
+              </div>
+            </details>
+            <details class="product-info-accordion__item">
+              <summary class="product-info-accordion__item-summary">
+                <div class="product-info-accordion__header">
+                  <span class="product-info-accordion__title">추가 정보</span>
+                  <span class="product-info-accordion__icon">아이콘</span>
+                </div>
+              </summary>
+              <div class="product-info-accordion__content-wrapper">
+                <div class="product-info-accordion__content">
+                  <p>상품정보제공고시</p>
+                  <ul>
+                    <li>제조연월: 수입제품으로 각 제품별 입고 시기에 따라 상이하여 정확한 제조연월 제공이 어렵습니다. 제조연월을 확인하시려면 고객센터에 문의하시기 바라며, 정확한 제조연월은 배송받으신 제품의 라벨을 참고하시기 바랍니다.</li>
+                  </ul>
+                  <ul>
+                    <li>A/S 책임자와 전화번호: (유)나이키코리아 온라인 스토어 고객센터 / 080-022-0182</li>
+                    <li>세탁방법 및 취급시 주의사항: 자세한 내용은 '<a href="#">자세히 보기</a>'를 클릭하여 확인 부탁드립니다.</li>
+                    <li>미성년자 권리 보호 안내: 자세한 내용은 '<a href="#">자세히 보기</a>' 를 클릭하여 확인 부탁드립니다.</li>
+                    <li>품질보증기준: 품질보증기간-섬유 및 일반 소재(구입 후 6개월), 가죽소재(구입 후 1년). 유통 중 손상되었거나 품질에 이상이 있는 제품에 한하여 소비자 피해 보상 규정에 의거 보상하여 드립니다. 단, 제품에 부착되어 있는 사용방법 및 취급 시 주의사항에 따라 제품을 관리해 주시고, 소비자 부주의로 인한 품질 이상 및 변형에 대해서는 책임을 지지 않습니다.</li>
+                  </ul>
+                  <ul>
+                    <li>실제 제품에는 재활용 소재 관련 내용이 표기되지 않을 수 있습니다.</li>
+                  </ul>
+                  <ul>
+                    <li>제조자/수입품의 경우 수입자를 함께 표기: Nike. Inc / (유)나이키코리아</li>
+                  </ul>
+                </div>
+              </div>
+            </details>
           </div>
         </div>
         <section class="related-products">
           <div class="related-products__header">
             <h2>추천 제품</h2>
             <div class="related-products__navigation">
-              <button class="related-products__arrow related-products__arrow--prev" aria-label="이전 제품 보기"><img src="/src/assets/icon/carousel-left.svg" alt="Previous products"></button>
-              <button class="related-products__arrow related-products__arrow--next" aria-label="다음 제품 보기"><img src="/src/assets/icon/carousel-right.svg" alt="Next products"></button>
+              <button class="related-products__arrow related-products__arrow--prev" aria-label="이전 제품 보기"><img src="/src/assets/icon/carousel-left.svg" alt="Previous products" /></button>
+              <button class="related-products__arrow related-products__arrow--next" aria-label="다음 제품 보기"><img src="/src/assets/icon/carousel-right.svg" alt="Next products" /></button>
             </div>
           </div>
           <div class="related-products__scroll-container">
@@ -262,5 +468,81 @@
         </section>
       </div>
     </div>
+    <footer style="margin-inline: auto; max-width:1920px; padding-inline:24px;">
+      <div class="f__dropdown">
+        <div class="footer__dropdown" style="min-width: 272px; ">
+          <input type="checkbox" id="footer__dropdown1" hidden />
+          <label for="footer__dropdown1" class="dropdown__list">
+            <span>안내</span
+            ><svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M18.9662 8.97595L12.0002 15.943L5.0332 8.97595" stroke="#111111" stroke-width="1.5" />
+            </svg>
+          </label>
+          <div class="dropdown__list-content1">
+            <ul>
+              <li><a href="/">멤버가입</a></li>
+              <li><a href="/">매장찾기</a></li>
+              <li><a href="/">나이키 저널</a></li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="footer__dropdown" style="min-width: 272px;">
+          <input type="checkbox" id="footer__dropdown2" hidden />
+          <label for="footer__dropdown2" class="dropdown__list">
+            <span>고객센터</span
+            ><svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M18.9662 8.97595L12.0002 15.943L5.0332 8.97595" stroke="#111111" stroke-width="1.5" />
+            </svg>
+          </label>
+          <div class="dropdown__list-content2">
+            <ul>
+              <li><a href="/">주문배송조회</a></li>
+              <li><a href="/">반품정책</a></li>
+              <li><a href="/">결제 방법</a></li>
+              <li><a href="/">공지사항</a></li>
+              <li><a href="/">문의하기</a></li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="footer__dropdown" style="min-width: 272px;">
+          <input type="checkbox" id="footer__dropdown3" hidden />
+          <label for="footer__dropdown3" class="dropdown__list dropdown__list3">
+            <span>회사소개</span
+            ><svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M18.9662 8.97595L12.0002 15.943L5.0332 8.97595" stroke="#111111" stroke-width="1.5" />
+            </svg>
+          </label>
+          <div class="dropdown__list-content3">
+            <ul>
+              <li><a href="/">About Nike</a></li>
+              <li><a href="/">소식</a></li>
+              <li><a href="/">채용</a></li>
+              <li><a href="/">투자자</a></li>
+              <li><a href="/">지속가능성</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="footer__terms">
+        <p>ⓒ 2024 Nike, Inc. All Rights Reserved</p>
+        <a href="/"><p>이용약관</p></a>
+        <a href="/"
+          ><p><span>개인정보처리방침</span></p></a
+        >
+        <a href="/"><p>위치정보이용약관</p></a>
+        <a href="/"><p>영상정보처리기기 운영 방침</p></a>
+      </div>
+
+      <div class="footer__company-info">
+        <p>
+          (유)나이키코리아 대표 Kimberlee Lynn Chang Mendes, 킴벌리 린 창 멘데스 | 서울 강남구 테헤란로 152 강남파이낸스센터 30층 | 통신판매업신고번호 2011-서울강남-03461 | 등록번호 220-88-09068 <u><a href="/">사업자 정보 확인</a></u>
+        </p>
+        <p>고객센터 전화 문의 <u>080-022-0182</u> FAX 02-6744-5880 | 이메일 <u>service@nike.co.kr</u> |</p>
+        <p>호스팅서비스사업자 (유)나이키코리아</p>
+      </div>
+    </footer>
   </body>
 </html>

--- a/src/pages/product_list_page.html
+++ b/src/pages/product_list_page.html
@@ -12,6 +12,212 @@
     <script type="module" src="/src/main.js"></script>
   </head>
   <body>
+    <div style="width: 100%; ">
+      <div style="background-color:var(--gray-50);">
+      <header class="header1" style="max-width: 1920px; margin-inline:auto; ">
+        <nav>
+          <span>매장찾기 ㅣ</span>
+          <span>고객센터 ㅣ</span>
+          <span>가입하기 ㅣ</span>
+          <span>로그인</span>
+        </nav>
+      </header>
+    </div>
+      <header class="header2" style="position: static; max-width: 1920px; margin-inline:auto;">
+        <a href="/" class="logo" style="margin-left:24px; @media (min-width: 960px) { margin-left:40px; }">
+          <svg width="59" height="21" viewBox="0 0 59 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M58.854 0L15.8132 18.2574C12.2297 19.7777 9.21516 20.5363 6.78586 20.5363C4.05249 20.5363 2.06131 19.5717 0.83849 17.6459C-0.747258 15.1611 -0.0541062 11.1656 2.66619 6.94786C4.28136 4.4826 6.33466 2.22005 8.33564 0.0555836C7.86482 0.820666 3.70918 7.73584 8.25391 10.9923C9.15304 11.6463 10.4314 11.9667 12.0041 11.9667C13.2662 11.9667 14.7146 11.7607 16.3069 11.3455L58.854 0Z" fill="#111111" />
+          </svg>
+        </a>
+        <nav class="nav-app">
+          <div class="search">
+            <a href="/" aria-label="검색"
+              ><svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M10.962 13.296C9.91599 13.9224 8.71921 14.2521 7.50001 14.25C6.6134 14.2512 5.7353 14.0772 4.91618 13.7379C4.09707 13.3986 3.35308 12.9008 2.72701 12.273C2.09924 11.6469 1.6014 10.9029 1.26212 10.0838C0.922837 9.26471 0.748797 8.38661 0.750006 7.50001C0.750006 5.63601 1.50501 3.94901 2.72701 2.72701C3.35308 2.09924 4.09707 1.6014 4.91618 1.26212C5.7353 0.922837 6.6134 0.748797 7.50001 0.750006C9.36401 0.750006 11.051 1.50501 12.273 2.72701C12.9008 3.35308 13.3986 4.09707 13.7379 4.91618C14.0772 5.7353 14.2512 6.6134 14.25 7.50001C14.2517 8.69741 13.9338 9.87357 13.329 10.907C12.812 11.789 12.895 12.895 13.618 13.618L17.471 17.471"
+                  stroke="#111111"
+                  stroke-width="1.5"
+                />
+              </svg>
+            </a>
+          </div>
+          <div class="my-info">
+            <a href="/" aria-label="내 정보"
+              ><svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M0.75 18V15C0.75 14.0054 1.14509 13.0516 1.84835 12.3483C2.55161 11.6451 3.50544 11.25 4.5 11.25H13.5C14.4946 11.25 15.4484 11.6451 16.1517 12.3483C16.8549 13.0516 17.25 14.0054 17.25 15V18M9 0.75C8.00544 0.75 7.05161 1.14509 6.34835 1.84835C5.64509 2.55161 5.25 3.50544 5.25 4.5C5.25 5.49456 5.64509 6.44839 6.34835 7.15165C7.05161 7.85491 8.00544 8.25 9 8.25C9.99456 8.25 10.9484 7.85491 11.6517 7.15165C12.3549 6.44839 12.75 5.49456 12.75 4.5C12.75 3.50544 12.3549 2.55161 11.6517 1.84835C10.9484 1.14509 9.99456 0.75 9 0.75Z"
+                  stroke="#111111"
+                  stroke-width="1.5"
+                />
+              </svg>
+            </a>
+          </div>
+          <div class="shopping-cart">
+            <a href="/" aria-label="장바구니"
+              ><svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M5.25 5.25V3C5.25 2.40326 5.48705 1.83097 5.90901 1.40901C6.33097 0.987053 6.90326 0.75 7.5 0.75H10.5C11.0967 0.75 11.669 0.987053 12.091 1.40901C12.5129 1.83097 12.75 2.40326 12.75 3C12.75 3.59674 12.5129 4.16903 12.091 4.59099C11.669 5.01295 11.0967 5.25 10.5 5.25H0.75V13.5C0.75 14.4946 1.14509 15.4484 1.84835 16.1517C2.55161 16.8549 3.50544 17.25 4.5 17.25H13.5C14.4946 17.25 15.4484 16.8549 16.1517 16.1517C16.8549 15.4484 17.25 14.4946 17.25 13.5V5.25H14.5"
+                  stroke="#111111"
+                  stroke-width="1.5"
+                />
+              </svg>
+            </a>
+          </div>
+          <input type="checkbox" id="menu-btn" />
+          <label tabindex="0" for="menu-btn" class="menu"
+            ><svg width="18" height="16" viewBox="0 0 18 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M18 1.25H0M18 8H0M18 14.75H0" stroke="#111111" stroke-width="1.5" />
+            </svg>
+          </label>
+
+          <div class="menu-list" style="min-width:320px;">
+            <label tabindex="0" for="menu-btn" class="menu-close-btn">
+              <svg width="29" height="29" viewBox="0 0 29 29" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <g opacity="0.18">
+                  <circle cx="14.5" cy="14.5" r="14.5" fill="#E5E5E5" />
+                  <path d="M6 7L21.9995 23" stroke="#111111" stroke-width="2" />
+                  <path d="M22 7L6.0005 23" stroke="#111111" stroke-width="2" />
+                </g>
+              </svg>
+            </label>
+
+            <div class="menu-user-btn">
+              <a href="/" class="togo-filled-00">가입하기</a>
+              <a href="/" class="togo-outlined-00">로그인</a>
+            </div>
+
+            <ul class="menu-category">
+              <li>
+                <a href="/"
+                  ><span>New & Featured</span
+                  ><svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M14.4854 10L22.9706 18.4853L14.4854 26.9706" stroke="#111111" stroke-width="2" />
+                  </svg>
+                </a>
+              </li>
+              <li>
+                <a href="/"
+                  ><span>Men</span
+                  ><svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M14.4854 10L22.9706 18.4853L14.4854 26.9706" stroke="#111111" stroke-width="2" />
+                  </svg>
+                </a>
+              </li>
+              <li>
+                <a href="/"
+                  ><span>Women</span
+                  ><svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M14.4854 10L22.9706 18.4853L14.4854 26.9706" stroke="#111111" stroke-width="2" />
+                  </svg>
+                </a>
+              </li>
+              <li>
+                <a href="/"
+                  ><span>Kids</span
+                  ><svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M14.4854 10L22.9706 18.4853L14.4854 26.9706" stroke="#111111" stroke-width="2" />
+                  </svg>
+                </a>
+              </li>
+              <li>
+                <a href="/"
+                  ><span>Sale</span
+                  ><svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M14.4854 10L22.9706 18.4853L14.4854 26.9706" stroke="#111111" stroke-width="2" />
+                  </svg>
+                </a>
+              </li>
+            </ul>
+            <ul class="menu-etc">
+              <a href="/"
+                ><li>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M11.99 18V16.5M9 9.75C9.00027 9.21339 9.14447 8.68668 9.41756 8.22476C9.69065 7.76284 10.0826 7.38262 10.5527 7.12373C11.0227 6.86485 11.5536 6.73678 12.0899 6.75286C12.6263 6.76895 13.1485 6.9286 13.6022 7.21519C14.0559 7.50177 14.4244 7.9048 14.6693 8.38225C14.9142 8.85971 15.0266 9.39411 14.9947 9.92978C14.9628 10.4654 14.7878 10.9827 14.488 11.4278C14.1882 11.8728 13.7745 12.2293 13.29 12.46C12.51 12.83 12 13.62 12 14.49V15M21.75 12C21.75 17.385 17.385 21.75 12 21.75C6.615 21.75 2.25 17.385 2.25 12C2.25 6.615 6.615 2.25 12 2.25C17.385 2.25 21.75 6.615 21.75 12Z"
+                      stroke="#111111"
+                      stroke-width="1.5"
+                      stroke-miterlimit="10"
+                    />
+                  </svg>
+                  <span>고객센터</span>
+                </li>
+              </a>
+              <a href="/"
+                ><li>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M8.25 8.25V6C8.25 5.40326 8.48705 4.83097 8.90901 4.40901C9.33097 3.98705 9.90326 3.75 10.5 3.75H13.5C14.0967 3.75 14.669 3.98705 15.091 4.40901C15.5129 4.83097 15.75 5.40326 15.75 6C15.75 6.59674 15.5129 7.16903 15.091 7.59099C14.669 8.01295 14.0967 8.25 13.5 8.25H3.75V16.5C3.75 17.4946 4.14509 18.4484 4.84835 19.1517C5.55161 19.8549 6.50544 20.25 7.5 20.25H16.5C17.4946 20.25 18.4484 19.8549 19.1517 19.1517C19.8549 18.4484 20.25 17.4946 20.25 16.5V8.25H17.5"
+                      stroke="#111111"
+                      stroke-width="1.5"
+                    />
+                  </svg>
+
+                  <span>장바구니</span>
+                </li>
+              </a>
+              <a href="/"
+                ><li>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M12 13.5V6.5C12 4.76 13.01 3.75 14.25 3.75H18.64L20.25 9.75M20.25 9.75H3.75M20.25 9.75V20.25H3.75V9.75M3.75 9.75L5.36 3.75H10.5" stroke="#111111" stroke-width="1.5" stroke-miterlimit="10" />
+                  </svg>
+
+                  <span>주문</span>
+                </li>
+              </a>
+              <a href="/"
+                ><li>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M20.25 5.25V16.5C20.25 17.74 19.24 18.75 18 18.75H6C4.76 18.75 3.75 17.74 3.75 16.5V5.25M8.25 18.5V11.25H15.75V18.5M12 11.25V18.5M1.5 5.25H22.5" stroke="#111111" stroke-width="1.5" stroke-miterlimit="10" />
+                  </svg>
+
+                  <span>매장 찾기</span>
+                </li>
+              </a>
+            </ul>
+          </div>
+          <div class="overlay"></div>
+        </nav>
+
+        <nav class="nav-web1" style="padding-left: 150px;">
+          <div><a href="/">New & Featured</a></div>
+          <div><a href="/">Men</a></div>
+          <div><a href="/">Women</a></div>
+          <div><a href="/">Kids</a></div>
+          <div><a href="/">Sale</a></div>
+        </nav>
+        <nav class="nav-web2">
+          <form action="/" class="header__search-input" method="GET">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M13.962 16.296C12.916 16.9224 11.7192 17.2521 10.5 17.25C9.6134 17.2512 8.7353 17.0772 7.91618 16.7379C7.09707 16.3986 6.35308 15.9008 5.72701 15.273C5.09924 14.6469 4.6014 13.9029 4.26212 13.0838C3.92284 12.2647 3.7488 11.3866 3.75001 10.5C3.75001 8.63601 4.50501 6.94901 5.72701 5.72701C6.35308 5.09924 7.09707 4.6014 7.91618 4.26212C8.7353 3.92284 9.6134 3.7488 10.5 3.75001C12.364 3.75001 14.051 4.50501 15.273 5.72701C15.9008 6.35308 16.3986 7.09707 16.7379 7.91618C17.0772 8.7353 17.2512 9.6134 17.25 10.5C17.2517 11.6974 16.9338 12.8736 16.329 13.907C15.812 14.789 15.895 15.895 16.618 16.618L20.471 20.471"
+                stroke="#111111"
+                stroke-width="1.5"
+              />
+            </svg>
+            <label for="header__search-input" class="sr-only">매장 위치 검색</label>
+            <input class="header__search-input__input" type="text" id="header__search-input" placeholder="검색" name="header__search-input__name" />
+          </form>
+          <a href="/" aria-label="위시리스트">
+            <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M22.794 9.75002C24.118 9.75002 25.362 10.266 26.298 11.201C27.2262 12.1309 27.7475 13.3911 27.7475 14.705C27.7475 16.0189 27.2262 17.2791 26.298 18.209L18 26.508L9.70096 18.209C8.77307 17.2791 8.25195 16.0192 8.25195 14.7055C8.25195 13.3919 8.77307 12.1319 9.70096 11.202C10.16 10.7403 10.706 10.3743 11.3075 10.125C11.909 9.87578 12.5539 9.74832 13.205 9.75002C14.529 9.75002 15.773 10.266 16.709 11.201L17.469 11.961L18 12.492L18.53 11.961L19.29 11.201C19.7492 10.7396 20.2953 10.3738 20.8967 10.1248C21.4982 9.87573 22.143 9.74835 22.794 9.75002Z"
+                stroke="#111111"
+                stroke-width="1.5"
+              />
+            </svg>
+          </a>
+          <a href="/" aria-label="장바구니"
+            ><svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M14.25 14.25V12C14.25 11.4033 14.4871 10.831 14.909 10.409C15.331 9.98705 15.9033 9.75 16.5 9.75H19.5C20.0967 9.75 20.669 9.98705 21.091 10.409C21.5129 10.831 21.75 11.4033 21.75 12C21.75 12.5967 21.5129 13.169 21.091 13.591C20.669 14.0129 20.0967 14.25 19.5 14.25H9.75V22.5C9.75 23.4946 10.1451 24.4484 10.8483 25.1517C11.5516 25.8549 12.5054 26.25 13.5 26.25H22.5C23.4946 26.25 24.4484 25.8549 25.1517 25.1517C25.8549 24.4484 26.25 23.4946 26.25 22.5V14.25H23.5"
+                stroke="#111111"
+                stroke-width="1.5"
+              />
+            </svg>
+          </a>
+        </nav>
+      </header>
+    </div>
     <div class="product-list-page">
       <div class="product-list-header">
         <h1 class="product-list-header__title">신제품 (749)</h1>
@@ -296,5 +502,81 @@
         </div>
       </div>
     </div>
+    <footer style="margin-inline: auto; max-width:1920px; padding-inline:24px;">
+      <div class="f__dropdown">
+        <div class="footer__dropdown" style="min-width: 272px;">
+          <input type="checkbox" id="footer__dropdown1" hidden />
+          <label for="footer__dropdown1" class="dropdown__list">
+            <span>안내</span
+            ><svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M18.9662 8.97595L12.0002 15.943L5.0332 8.97595" stroke="#111111" stroke-width="1.5" />
+            </svg>
+          </label>
+          <div class="dropdown__list-content1">
+            <ul>
+              <li><a href="/">멤버가입</a></li>
+              <li><a href="/">매장찾기</a></li>
+              <li><a href="/">나이키 저널</a></li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="footer__dropdown" style="min-width: 272px;">
+          <input type="checkbox" id="footer__dropdown2" hidden />
+          <label for="footer__dropdown2" class="dropdown__list">
+            <span>고객센터</span
+            ><svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M18.9662 8.97595L12.0002 15.943L5.0332 8.97595" stroke="#111111" stroke-width="1.5" />
+            </svg>
+          </label>
+          <div class="dropdown__list-content2">
+            <ul>
+              <li><a href="/">주문배송조회</a></li>
+              <li><a href="/">반품정책</a></li>
+              <li><a href="/">결제 방법</a></li>
+              <li><a href="/">공지사항</a></li>
+              <li><a href="/">문의하기</a></li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="footer__dropdown" style="min-width: 272px;">
+          <input type="checkbox" id="footer__dropdown3" hidden />
+          <label for="footer__dropdown3" class="dropdown__list dropdown__list3">
+            <span>회사소개</span
+            ><svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M18.9662 8.97595L12.0002 15.943L5.0332 8.97595" stroke="#111111" stroke-width="1.5" />
+            </svg>
+          </label>
+          <div class="dropdown__list-content3">
+            <ul>
+              <li><a href="/">About Nike</a></li>
+              <li><a href="/">소식</a></li>
+              <li><a href="/">채용</a></li>
+              <li><a href="/">투자자</a></li>
+              <li><a href="/">지속가능성</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="footer__terms">
+        <p>ⓒ 2024 Nike, Inc. All Rights Reserved</p>
+        <a href="/"><p>이용약관</p></a>
+        <a href="/"
+          ><p><span>개인정보처리방침</span></p></a
+        >
+        <a href="/"><p>위치정보이용약관</p></a>
+        <a href="/"><p>영상정보처리기기 운영 방침</p></a>
+      </div>
+
+      <div class="footer__company-info">
+        <p>
+          (유)나이키코리아 대표 Kimberlee Lynn Chang Mendes, 킴벌리 린 창 멘데스 | 서울 강남구 테헤란로 152 강남파이낸스센터 30층 | 통신판매업신고번호 2011-서울강남-03461 | 등록번호 220-88-09068 <u><a href="/">사업자 정보 확인</a></u>
+        </p>
+        <p>고객센터 전화 문의 <u>080-022-0182</u> FAX 02-6744-5880 | 이메일 <u>service@nike.co.kr</u> |</p>
+        <p>호스팅서비스사업자 (유)나이키코리아</p>
+      </div>
+    </footer>
   </body>
 </html>

--- a/src/pages/styles/product_detail_page.css
+++ b/src/pages/styles/product_detail_page.css
@@ -1,6 +1,11 @@
+@import url('/src/components/styles/header.css');
+@import url('/src/components/styles/footer.css');
+
 /* 상품 상세 페이지 컴포넌트 */
 .product-detail-page {
   width: 100%;
+  max-width: 1920px;
+  margin-inline: auto;
   padding-bottom: 48px;
 }
 
@@ -236,6 +241,7 @@
     grid-column: 7 / span 6;
     display: flex;
     flex-direction: column;
+    padding-inline: 0px;
     padding-left: 24px;
   }
 
@@ -376,7 +382,7 @@
   justify-content: center;
   align-items: center;
   height: 104px;
-  background: var(--grey-50);
+  background: var(--gray-50);
   margin-block: 36px;
   margin-top: 32px;
   text-align: center;
@@ -526,6 +532,11 @@
 /* 관련 상품 컴포넌트 */
 .related-products {
   grid-column: 1 / -1;
+  padding-left: 24px;
+
+  @media (min-width: 960px) {
+    padding-left: 0px;
+  }
 }
 
 .related-products__header {

--- a/src/pages/styles/product_list_page.css
+++ b/src/pages/styles/product_list_page.css
@@ -1,3 +1,6 @@
+@import url('/src/components/styles/header.css');
+@import url('/src/components/styles/footer.css');
+
 .product-list-page {
   width: 100%;
   max-width: 1920px;
@@ -228,8 +231,8 @@
     }
 
     .product-card__image-wrapper {
-      min-width: 196px;
-      min-height: 196px;
+      min-width: 147px;
+      min-height: 147px;
 
       > img {
         width: 100%;


### PR DESCRIPTION
## PR 유형

- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링

### PR 상세
제품 리스트 페이지 및 제품 상세 페이지에 우섭님이 만드신 헤더, 푸터 조립 하였습니다.
작성 페이지의 레이아웃에 알맞게 적용시키기 위해 몇몇 속성들의 경우 인라인으로 덧붙였습니다.
그리고 보통의 경우, footer는 모바일 환경에서 padding-left : 24px 웹뷰에서 padding-left : 48px이 적용되어 있는 것으로 보입니다.
인라인으로는 미디어쿼리를 적용시킬 수 없어, 이 부분을 적용하기 위해 푸터와 헤더의 CSS속성을 수정할지 논의가 필요합니다.

## 이슈
resolves #69 
